### PR TITLE
Use python from environment

### DIFF
--- a/bin/editor.py
+++ b/bin/editor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # pylint: disable=missing-module-docstring
 import sys
 import os


### PR DESCRIPTION
Fixes "No module named pynvim" when using python virtual environments (not using system python)