### PR TITLE
Feature: save buffers info including undo

### DIFF
--- a/autoload/rnvimr/util.vim
+++ b/autoload/rnvimr/util.vim
@@ -1,0 +1,20 @@
+function! rnvimr#util#sync_undo(src, dst, do_bw) abort
+    if !&undofile || !filereadable(a:dst)
+        return
+    endif
+    let src = resolve(a:src)
+    if &undodir == '.'
+        let undo_path = printf('%s/.%s.un~', fnamemodify(src, ':p:h'), fnamemodify(src, ':t'))
+    else
+        let undo_path = printf('%s/%s', &undodir, fnamemodify(src, ':p:gs?/?%?'))
+    endif
+    if !filereadable(undo_path)
+        return
+    endif
+    execute printf('%s edit %s', a:do_bw ? 'noautocmd' : '', a:dst)
+    execute 'noautocmd silent! rundo' . fnameescape(undo_path)
+    noautocmd silent! write
+    if a:do_bw
+        noautocmd silent! bwipeout
+    endif
+endfunction

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -7,6 +7,9 @@ from .patch import rifle
 from .patch import ueberzug
 from .patch import ui
 from .patch import viewmiller
+from .patch import action
 from .patch import directory
 from .patch import loader
 from .patch import statusbar
+from .patch import ccommands
+from .patch import shutil_generatorized

--- a/lib/patch/action.py
+++ b/lib/patch/action.py
@@ -1,0 +1,32 @@
+"""
+Patch ranger.core.actions.Actions
+
+"""
+import os
+from ranger.core.actions import Actions
+
+def enhance_rename(client):
+    """
+    Enhance low-level rename method to save information in loaded buffers.
+
+    :param client object: Object of attached neovim session
+    """
+    def rename(self, src, dest):
+        if hasattr(src, 'path'):
+            src = src.path
+
+        try:
+            os.makedirs(os.path.dirname(dest))
+        except OSError:
+            pass
+        try:
+            os.rename(src, dest)
+        except OSError as err:
+            self.notify(err)
+            return False
+        else:
+            dst = os.path.abspath(dest)
+            client.move_buf(src, dst)
+        return True
+
+    Actions.rename = rename

--- a/lib/patch/ccommands.py
+++ b/lib/patch/ccommands.py
@@ -1,0 +1,140 @@
+"""
+Patch ranger.config.commands
+
+"""
+import os
+import tempfile
+import shlex
+
+
+def enhance_quit(commands, client):
+    """
+    Make ranger pretend to quit.
+
+    :param commands dict: command name as key, command class as val
+    :param client object: Object of attached neovim session
+    """
+
+    quit_cls = commands.get_command('quit')
+    if not quit_cls:
+        return
+
+    def execute(self):
+
+        if len(self.fm.tabs) >= 2:
+            self.fm.tab_close()
+        else:
+            client.hide_window()
+
+    quit_cls.execute = execute
+
+
+def alias_edit_file(commands):
+    """
+    Use EditFile alias for edit_file and edit command.
+
+    :param commands dict: command name as key, command class as val
+    """
+
+    if not commands.get_command('EditFile'):
+        return
+
+    commands.alias('edit_file', 'EditFile')
+    commands.alias('edit', 'EditFile')
+
+
+def enhance_bulkrename(commands, client):
+    """
+    Bulkrename need a block workflow, so restore the raw editor to edit file name.
+    Enhance bulkrename to save information in loaded buffers.
+
+    :param commands dict: command name as key, command class as val
+    :param client object: Object of attached neovim session
+    """
+
+    bulkrename_cls = commands.get_command('bulkrename')
+    if not bulkrename_cls:
+        return
+
+    def _parse_cmd_and_move_buf(content):
+        for line in content.decode('utf-8').splitlines():
+            cmd = shlex.split(line, comments=True)
+            if cmd:
+                try:
+                    src, dst = cmd[-2:]
+                except ValueError:
+                    pass
+                else:
+                    client.move_buf(os.path.abspath(src), os.path.abspath(dst))
+
+    def execute(self):
+        from ranger.container.file import File  # pylint: disable=import-outside-toplevel
+        # pylint: disable=import-outside-toplevel
+        from ranger.ext.shell_escape import shell_escape as esc
+
+        editor = os.getenv('EDITOR')
+        if not editor:
+            editor = 'nvim'
+
+        # Create and edit the file list
+        filenames = [f.relative_path for f in self.fm.thistab.get_selection()]
+        with tempfile.NamedTemporaryFile(delete=False) as listfile:
+            listpath = listfile.name
+            listfile.write('\n'.join(filenames).encode(encoding='utf-8', errors='surrogateescape'))
+        self.fm.execute_file([File(listpath)], app='{}'.format(editor))
+        with open(listpath, 'r', encoding='utf-8', errors='surrogateescape') as listfile:
+            new_filenames = listfile.read().split("\n")
+        os.unlink(listpath)
+        if all(a == b for a, b in zip(filenames, new_filenames)):
+            self.fm.notify('No renaming to be done!')
+            return
+
+        # Generate script
+        with tempfile.NamedTemporaryFile() as cmdfile:
+            script_lines = []
+            script_lines.append('# This file will be executed when you close the editor.')
+            script_lines.append('# Please double-check everything, clear the file to abort.')
+            new_dirs = []
+            for old, new in zip(filenames, new_filenames):
+                if old != new:
+                    basepath, _ = os.path.split(new)
+                    if (basepath and basepath not in new_dirs and not os.path.isdir(basepath)):
+                        script_lines.append('mkdir -vp -- {dir}'.format(dir=esc(basepath)))
+                        new_dirs.append(basepath)
+                    script_lines.append('mv -vi -- {old} {new}'.format(old=esc(old), new=esc(new)))
+            # Make sure not to forget the ending newline
+            script_content = '\n'.join(script_lines) + '\n'
+            cmdfile.write(script_content.encode(encoding='utf-8', errors='surrogateescape'))
+            cmdfile.flush()
+
+            # Open the script and let the user review it, then check if the
+            # script was modified by the user
+            self.fm.execute_file([File(cmdfile.name)], app='{}'.format(editor))
+            cmdfile.seek(0)
+            new_content = cmdfile.read()
+            script_was_edited = (script_content != new_content)
+
+            # Do the renaming
+            self.fm.run(['/bin/sh', cmdfile.name], flags='w')
+
+            _parse_cmd_and_move_buf(new_content)
+
+        # Retag the files, but only if the script wasn't changed during review,
+        # because only then we know which are the source and destination files.
+        if not script_was_edited:
+            tags_changed = False
+            for old, new in zip(filenames, new_filenames):
+                if old != new:
+                    oldpath = self.fm.thisdir.path + '/' + old
+                    newpath = self.fm.thisdir.path + '/' + new
+                    if oldpath in self.fm.tags:
+                        old_tag = self.fm.tags.tags[oldpath]
+                        self.fm.tags.remove(oldpath)
+                        self.fm.tags.tags[newpath] = old_tag
+                        tags_changed = True
+            if tags_changed:
+                self.fm.tags.dump()
+        else:
+            self.fm.notify('files have not been retagged')
+
+    bulkrename_cls.execute = execute

--- a/lib/patch/shutil_generatorized.py
+++ b/lib/patch/shutil_generatorized.py
@@ -1,0 +1,26 @@
+"""
+Patch ranger.ext.shutil_generatorized
+
+"""
+import os
+from shutil import _basename
+from ranger.ext import shutil_generatorized
+from ranger.ext.safe_path import get_safe_path
+
+def wrap_move(client):
+    """
+    CopyLoader with do_cut parameter will invoke this method.
+    Wrap low-level move method to save information in loaded buffers.
+
+    :param client object: Object of attached neovim session
+    """
+    def move(src, dst, overwrite, make_safe_path=get_safe_path):
+
+        real_dst = os.path.join(dst, _basename(src))
+        if not overwrite:
+            real_dst = make_safe_path(real_dst)
+        yield from raw_move(src, dst, overwrite, make_safe_path)
+        client.move_buf(src, real_dst)
+
+    raw_move = shutil_generatorized.move
+    shutil_generatorized.move = move

--- a/lib/patch/ui.py
+++ b/lib/patch/ui.py
@@ -6,7 +6,7 @@ Patch ranger.gui.ui.UI
 import curses
 from ranger.gui.ui import UI
 
-def adapt_draw_border(attr, client):
+def enhance_draw_border(attr, client):
     """
     Call by draw_border, fix UI to draw a border.
 

--- a/lib/patch/viewmiller.py
+++ b/lib/patch/viewmiller.py
@@ -9,7 +9,7 @@ import curses
 from ranger.gui.widgets.view_miller import ViewMiller
 
 
-def adapt_draw_border(attr):
+def enhance_draw_border(attr):
     """
     Call by draw_border, fix ViewMiller can't draw border properly.
 

--- a/lib/rcommand.py
+++ b/lib/rcommand.py
@@ -102,7 +102,7 @@ class AttachFile(Command):
                 self.fm.thisdir.refilter()
                 self.fm.thisdir.move_to_obj(path)
 
-                if self.fm.thisfile.has_preview():
+                if hasattr(self.fm.thisfile, 'has_preview') and self.fm.thisfile.has_preview():
                     descr = 'Scroll the line for preview file'
                     loadable = Loadable(self.scroll_preview(line - 1), descr)
                     self.fm.loader.add(loadable, append=True)


### PR DESCRIPTION
Move files outside neovim, the dst files will lose the undo, and
the information in buffers loaded src files.

This issue is solved by enhancing low-level function such as rename,
shutil_move and bulkrename.