### PR TITLE
fix(macos): missing a window resize signal (#69)

### DIFF
--- a/autoload/rnvimr.vim
+++ b/autoload/rnvimr.vim
@@ -68,6 +68,9 @@ endfunction
 
 function! s:create_ranger(cmd) abort
     let init_layout = rnvimr#layout#get_init_layout()
+    if get(g:, 'rnvimr_draw_border', 1) && (has('mac') || has('macunix'))
+        let init_layout.width -= 1
+    endif
     call rnvimr#context#bufnr(nvim_create_buf(v:false, v:true))
     call rnvimr#context#winid(
                 \ nvim_open_win(rnvimr#context#bufnr(), v:true, init_layout))

--- a/autoload/rnvimr/rpc.vim
+++ b/autoload/rnvimr/rpc.vim
@@ -26,10 +26,6 @@ function! rnvimr#rpc#attach_file(file) abort
     endif
 endfunction
 
-function! rnvimr#rpc#set_host_chan_id(id) abort
-    let s:host_chan_id = a:id
-endfunction
-
 function! rnvimr#rpc#reset() abort
     let s:host_chan_id = -1
 endfunction
@@ -66,6 +62,15 @@ endfunction
 
 " ranger to neovim
 " =================================================================================================
+function! rnvimr#rpc#host_ready(id) abort
+    let s:host_chan_id = a:id
+    if get(g:, 'rnvimr_draw_border', 1) && (has('mac') || has('macunix'))
+        let layout = nvim_win_get_config(rnvimr#context#winid())
+        let layout.width += 1
+        call nvim_win_set_config(rnvimr#context#winid(), layout)
+    endif
+endfunction
+
 function! rnvimr#rpc#list_buf_name_nr() abort
     let buf_dict = {}
     for buf in filter(getbufinfo({'buflisted': 1}), 'v:val.changed == 0')

--- a/ranger/plugins/host.py
+++ b/ranger/plugins/host.py
@@ -28,9 +28,9 @@ class Host():
         # job start with pty option in neovim only use stdout to communicate
         if os.getenv('RNVIMR_CHECKHEALTH'):
             print('RNVIMR_CHECKHEALTH', self.fm.host_id, 'RNVIMR_CHECKHEALTH')
-            self.nvim.call('rnvimr#rpc#set_host_chan_id', self.fm.host_id)
+            self.nvim.call('rnvimr#rpc#host_ready', self.fm.host_id)
         else:
-            self.nvim.call('rnvimr#rpc#set_host_chan_id', self.fm.host_id)
+            self.nvim.call('rnvimr#rpc#host_ready', self.fm.host_id)
 
     def hook_ready(self):
         """


### PR DESCRIPTION
nvim's terminal in macOS seemly is different from in Linux's.
Resize window to render border after ranger's host is ready.