### PR TITLE
feat: add RnvimrClose command

### DIFF
--- a/autoload/rnvimr.vim
+++ b/autoload/rnvimr.vim
@@ -162,6 +162,16 @@ function! rnvimr#toggle() abort
     endif
 endfunction
 
+function! rnvimr#close() abort
+    let win_hd = rnvimr#context#winid()
+    if rnvimr#context#bufnr() != -1
+        \ && win_hd != -1 && nvim_win_is_valid(win_hd)
+        \ && nvim_get_current_win() == win_hd
+            call nvim_win_close(win_hd, 0)
+            call rnvimr#rpc#clear_image()
+    endif
+endfunction
+
 function! rnvimr#open(path) abort
     let isdir = isdirectory(a:path)
     if rnvimr#context#bufnr() != -1

--- a/plugin/rnvimr.vim
+++ b/plugin/rnvimr.vim
@@ -5,6 +5,7 @@ endif
 let g:loaded_rnvimr = 1
 
 command! -nargs=0 RnvimrToggle call rnvimr#toggle()
+command! -nargs=0 RnvimrClose call rnvimr#close()
 command! -nargs=* RnvimrResize call rnvimr#resize(<args>)
 command! -nargs=0 RnvimrStartBackground call rnvimr#init('', 1)
 


### PR DESCRIPTION
Press '<C-\\><C-\\>' in terminal mode will crash ranger (this is a ranger bug), by mapping '<C-\\><C-\\>' to `:RnvimClose` we can quit ranger instead of crash it.