### PR TITLE
fix buffer showing artifacts from old dir

### DIFF
--- a/autoload/rnvimr.vim
+++ b/autoload/rnvimr.vim
@@ -164,6 +164,7 @@ function! rnvimr#toggle() abort
         else
             call rnvimr#rpc#attach_file_once(expand('%:p'))
             call s:reopen_win()
+            call rnvimr#rpc#clear_image()
         endif
     else
         call rnvimr#init()


### PR DESCRIPTION
I was able to solve the issue reported at #159 by calling the clear_image rpc when attaching a new file. 

I didn't spend too much time reading the code, so this might not be the best solution possible. However, it was good enough to make the plugin usable for me.